### PR TITLE
Add parsePDF utility

### DIFF
--- a/pdf-utils/parsePDF.js
+++ b/pdf-utils/parsePDF.js
@@ -1,0 +1,16 @@
+const pdfParse = require('pdf-parse');
+
+/**
+ * Extract text from a PDF buffer.
+ * @param {Buffer} buffer - Raw PDF data.
+ * @returns {Promise<string>} Resolves with plain text from the PDF.
+ */
+async function parsePDF(buffer) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new TypeError('Buffer expected');
+  }
+  const data = await pdfParse(buffer);
+  return data.text;
+}
+
+module.exports = { parsePDF };


### PR DESCRIPTION
## Summary
- add `parsePDF` helper to extract plain text from a PDF buffer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bae95cd0c832dab71636da81e533f