### PR TITLE
Fix prompt template and markdown blocks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@
 - Embeddings stored in memory (or vector store)
 - Question asked → top-k chunks fetched → answer generated via prompt
 - Answers + questions logged in Firestore
+```
 
 ## Prompt Template
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,3 +8,4 @@ This folder contains the React/Next.js UI for the PDF Q&A Chatbot.
 cd frontend
 npm install
 npm run dev
+```

--- a/vertex-utils/promptHelpers.js
+++ b/vertex-utils/promptHelpers.js
@@ -1,8 +1,7 @@
 // vertex-utils/promptHelpers.js
 
 function buildPrompt(question, contextChunk) {
-  return `
-You are a helpful assistant. Use the context below to answer the question.
+  return `You are a helpful assistant. Use the context below to answer the question.
 
 Context:
 ${contextChunk}
@@ -10,8 +9,7 @@ ${contextChunk}
 Question:
 ${question}
 
-Answer:
-`;
+Answer:`;
 }
 
 module.exports = { buildPrompt };


### PR DESCRIPTION
## Summary
- fix leading newline in promptHelpers.js
- close code blocks in docs and frontend README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ba7e8f300832da29a2dc853337680