### PR TITLE
Fix newline in prompt

### DIFF
--- a/vertex-utils/promptHelpers.js
+++ b/vertex-utils/promptHelpers.js
@@ -1,8 +1,7 @@
 // vertex-utils/promptHelpers.js
 
 function buildPrompt(question, contextChunk) {
-  return `
-You are a helpful assistant. Use the context below to answer the question.
+  return `You are a helpful assistant. Use the context below to answer the question.
 
 Context:
 ${contextChunk}
@@ -10,8 +9,7 @@ ${contextChunk}
 Question:
 ${question}
 
-Answer:
-`;
+Answer:`;
 }
 
 module.exports = { buildPrompt };


### PR DESCRIPTION
## Summary
- update promptHelpers.js to start template literal immediately without newline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ba8efb41c832da93eae8fa39f7712