### PR TITLE
Implement text chunking and summarization utilities

### DIFF
--- a/functions/chunkText.js
+++ b/functions/chunkText.js
@@ -1,0 +1,23 @@
+// functions/chunkText.js
+
+/**
+ * Split plain text into an array of chunks of roughly `size` words each.
+ * @param {string} text - The text to chunk
+ * @param {number} [size=300] - Approximate number of words per chunk
+ * @returns {string[]} Array of text chunks
+ */
+function chunkText(text, size = 300) {
+  if (!text || typeof text !== 'string') {
+    return [];
+  }
+
+  const words = text.trim().split(/\s+/);
+  const chunks = [];
+  for (let i = 0; i < words.length; i += size) {
+    const chunkWords = words.slice(i, i + size);
+    chunks.push(chunkWords.join(' '));
+  }
+  return chunks;
+}
+
+module.exports = { chunkText };

--- a/functions/generateSummaries.js
+++ b/functions/generateSummaries.js
@@ -1,0 +1,37 @@
+// functions/generateSummaries.js
+
+const axios = require('axios');
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+/**
+ * Call the Gemini API to return a 1-2 sentence summary of the provided text.
+ * @param {string} chunk
+ * @returns {Promise<string>} summary text
+ */
+async function summarizeChunk(chunk) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${GEMINI_API_KEY}`;
+  const prompt = `Summarize the following text in 1-2 sentences:\n\n${chunk}`;
+  try {
+    const response = await axios.post(url, {
+      contents: [{ parts: [{ text: prompt }] }]
+    });
+    return response.data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || '';
+  } catch (err) {
+    console.error('Error summarizing chunk', err.response?.data || err.message);
+    return '';
+  }
+}
+
+/**
+ * Generate summaries for an array of text chunks.
+ * @param {string[]} chunks
+ * @returns {Promise<Array<{chunk: string, summary: string}>>}
+ */
+async function generateSummaries(chunks) {
+  const results = await Promise.all(
+    chunks.map(async (chunk) => ({ chunk, summary: await summarizeChunk(chunk) }))
+  );
+  return results;
+}
+
+module.exports = { summarizeChunk, generateSummaries };


### PR DESCRIPTION
## Summary
- add `chunkText` utility for splitting text into ~300-word sections
- add `generateSummaries` utility for summarizing text chunks with Gemini

## Testing
- `node -e "const {chunkText}=require('./functions/chunkText'); console.log(chunkText('one two three four five six seven eight nine ten eleven',3));"`
- `node - <<'NODE'
const {generateSummaries} = require('./functions/generateSummaries');
(async () => {
  const results = await generateSummaries(['This is a test chunk.']);
  console.log(results);
})();
NODE` *(fails: Cannot find module 'axios')*


------
https://chatgpt.com/codex/tasks/task_e_685baf40c8d8832d863ab9e62b6a0cc8